### PR TITLE
Fixed assert happening on empty dir

### DIFF
--- a/frametree/xnat/cs.py
+++ b/frametree/xnat/cs.py
@@ -139,9 +139,13 @@ class XnatViaCS(Xnat):
             resource_path = input_mount / path
             if not resource_path.exists():
                 resource_path = input_mount / path.replace("resources", "RESOURCES")
-            assert (
-                resource_path.exists()
-            ), f"Resource path {path} not found in {input_mount}: {list(input_mount.iterdir())}"  # noqa
+            if not resource_path.exists():
+                logger.info(
+                    "Resource path %s not found in %s, falling back to API access",
+                    path,
+                    input_mount,
+                )
+                return super().get_fileset(entry, datatype)
             fspaths = [
                 p
                 for p in resource_path.iterdir()

--- a/frametree/xnat/tests/test_store.py
+++ b/frametree/xnat/tests/test_store.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from datetime import datetime
 from functools import reduce
 from pathlib import Path
+from tempfile import mkdtemp
 from typing import Any
 
 import pytest
@@ -364,3 +365,55 @@ def test_single_load(
 
     assert len(list(frameset.rows("session"))) == 1
     assert caplog.text.count("Adding leaf to data tree at path") == 1
+
+
+def test_get_fileset_falls_back_to_api_when_resource_missing(
+    xnat_repository: Xnat,
+    source_data: Path,
+    run_prefix: str,
+    tmp_path: Path,
+    caplog: Any,
+) -> None:
+    blueprint = TestXnatDatasetBlueprint(
+        dim_lengths=[1, 1, 1],
+        scans=[
+            ScanBP(
+                name="scan1",
+                resources=[
+                    FileBP(path="Text", datatype=PlainText, filenames=["file.txt"]),
+                ],
+            ),
+        ],
+    )
+    project_id = run_prefix + "csfallback" + str(hex(random.getrandbits(16)))[2:]
+    blueprint.make_dataset(
+        dataset_id=project_id,
+        store=xnat_repository,
+        source_data=source_data,
+        name="",
+    )
+
+    # Create a partial input mount, scan dir exists but resource is missing
+    partial_mount = tmp_path / "input"
+    partial_mount.mkdir()
+    (partial_mount / "SCANS" / "1").mkdir(parents=True)
+
+    cs_store = XnatViaCS(
+        server=xnat_repository.server,
+        user=xnat_repository.user,
+        password=xnat_repository.password,
+        cache_dir=Path(mkdtemp()),
+        row_frequency=MedImage.session,
+        input_mount=partial_mount,
+        output_mount=tmp_path / "output",
+    )
+    dataset = cs_store.load_frameset(project_id, name="")
+
+    with caplog.at_level(logging.INFO, logger="frametree"):
+        for row in dataset.rows("session"):
+            for entry in row.entries:
+                item = entry.item
+                # Verify we got a valid file back via API fallback
+                assert list(item.fspaths)
+
+    assert "falling back to API access" in caplog.text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ doc = [
 test = [
     "frametree-bids",
     "medimages4tests >=0.3",
+    "openneuro-py <2025",
     "pydra2app",
     "pytest >=5.4.3",
     "pytest-cov >=2.12.1",
@@ -95,3 +96,6 @@ strict = true
 namespace_packages = true
 explicit_package_bases = true
 exclude = ["tests", "scripts", "docs", "build", "dist"]
+
+[tool.uv]
+prerelease = "allow"


### PR DESCRIPTION
Fixes #18 

The bug was caused by an assert being triggered when a resource did not exist inside of a mounted directory, causing the programme to exit.

It has now been replaced with a fallback to using the API for that resource instead.

Test also added, along with a dependency for the test environment.